### PR TITLE
Move the algorithm directly into CompressedCertificate message

### DIFF
--- a/draft-ietf-tls-certificate-compression.md
+++ b/draft-ietf-tls-certificate-compression.md
@@ -75,9 +75,9 @@ compressed client certificates.  Note that CertificareRequest messages are not
 supported by TLS versions prior to 1.3.
 
 By sending a compress_certificate extension, the sender indicates to the peer
-the certificate compression algorithms it is willing to decompress.  The
-"extension_data" field of this extension in the Extension message SHALL contain
-a CertificateCompressionAlgorithms value:
+the certificate compression algorithms it is willing to use for decompression.
+The "extension_data" field of this extension SHALL contain a
+CertificateCompressionAlgorithms value:
 
 ~~~
     enum {

--- a/draft-ietf-tls-certificate-compression.md
+++ b/draft-ietf-tls-certificate-compression.md
@@ -71,7 +71,7 @@ message to the peer.  Whenever it is sent by the client as a ClientHello message
 extension ([RFC5246], Section 7.4.1.4), it indicates the support for compressed
 server certificates.  Whenever it is sent by the server as a CertificateRequest
 extension ([I-D.ietf-tls-tls13], Section 4.3.2), it indicates the support for
-compressed client certificates.  Note that CertificareRequest messages are not
+compressed client certificates.  Note that CertificateRequest messages are not
 supported by TLS versions prior to 1.3.
 
 By sending a compress_certificate extension, the sender indicates to the peer


### PR DESCRIPTION
This allows for stateless parsers to easily understand the contents of
the message without having to keep track of the handshake state.

This also decouples client and server compression parameters, allowing
compression being negotiated in only one direction.