### PR TITLE
Reserve codepoint 0

### DIFF
--- a/draft-ietf-tls-certificate-compression.md
+++ b/draft-ietf-tls-certificate-compression.md
@@ -193,8 +193,9 @@ The entries in the registry are:
 
 | Algorithm Number | Description              |
 |:-----------------|:-------------------------|
-| 0                | zlib                     |
-| 1                | brotli                   |
+| 0                | Reserved                 |
+| 1                | zlib                     |
+| 2                | brotli                   |
 | 224 to 255       | Reserved for Private Use |
 
 The values in this registry shall be allocated under "IETF Review" policy for


### PR DESCRIPTION
As suggested by @kaduk and @seanturner it's probably a good idea to keep codepoint "0" unassigned. FWIW, it seems some other TLS registries do the same (but it's not consistent).