### PR TITLE
vector size (in octets) is a multiple of 2

### DIFF
--- a/draft-ietf-tls-certificate-compression.md
+++ b/draft-ietf-tls-certificate-compression.md
@@ -90,7 +90,7 @@ CertificateCompressionAlgorithms value:
     } CertificateCompressionAlgorithm;
 
     struct {
-        CertificateCompressionAlgorithm algorithms<1..2^8-1>;
+        CertificateCompressionAlgorithm algorithms<2..2^8-2>;
     } CertificateCompressionAlgorithms;
 ~~~
 


### PR DESCRIPTION
IIUC the convention is to express the actual bounds based on the size of the elements.